### PR TITLE
remove move to

### DIFF
--- a/role.upgrader.js
+++ b/role.upgrader.js
@@ -21,7 +21,7 @@ var roleUpgrader = {
             var sources = creep.room.find(FIND_SOURCES);
             if(creep.harvest(sources[1]) == ERR_NOT_IN_RANGE) {
                 creep.moveTo(sources[1], {visualizePathStyle: {stroke: '#ffaa00'}});
-            } else { creep.moveTo(8,41)}
+            }
         }
 	}
 };


### PR DESCRIPTION
The harvest if statement says when creep.harvest returns "ERR_NOT_IN_RANGE" it will move to, however when the creep is next to the source there is a different return value. By having an else statement say "moveTo" after the ERR_NOT_IN_RANGE would cause it to move away before harvesting